### PR TITLE
CVE-2013-4342: xinetd ignores user and group directives for TCPMUX services

### DIFF
--- a/xinetd/builtins.c
+++ b/xinetd/builtins.c
@@ -617,7 +617,7 @@ static void tcpmux_handler( const struct server *serp )
    if( SC_IS_INTERNAL( scp ) ) {
       SC_INTERNAL(scp, nserp);
    } else {
-      exec_server(nserp);
+      child_process(nserp);
    }
 }
 


### PR DESCRIPTION
Originally reported to Debian in 2005 http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=324678 and rediscovered https://bugzilla.redhat.com/show_bug.cgi?id=1006100, xinetd would execute configured TCPMUX services without dropping privilege to match the service configuration allowing the service to run with same privilege as the xinetd process (root).
