### PR TITLE
Document REMOTE_HOST variable

### DIFF
--- a/xinetd/xinetd.man
+++ b/xinetd/xinetd.man
@@ -175,6 +175,10 @@ default configuration file
 .B /var/run/xinetd.dump
 default dump file
 .PD
+.\" *********************** ENVIRONMENT ****************************
+.SH "ENVIRONMENT"
+.B REMOTE_HOST
+Contains the IP address of the client.
 .\" *********************** SEE ALSO ****************************
 .SH "SEE ALSO"
 .I "inetd(8),"


### PR DESCRIPTION
Adds a section about ENVIRONMENT in man page and
documents the only variable present.
