### PR TITLE
configure: Use HAVE_SYS_RESOURCE_H to guard sys/resource.h inclusion

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -11,7 +11,7 @@ AC_CACHE_VAL(xinetd_cv_type_$1,
 #if HAVE_NETDB_H
 #include <netdb.h>
 #endif
-#if HAVE_RLIM_T
+#if HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
 #endif
 #if HAVE_STDINT_H

--- a/configure
+++ b/configure
@@ -7640,7 +7640,7 @@ cat >>conftest.$ac_ext <<_ACEOF
 #if HAVE_NETDB_H
 #include <netdb.h>
 #endif
-#if HAVE_RLIM_T
+#if HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
 #endif
 #if HAVE_STDINT_H
@@ -7686,7 +7686,7 @@ cat >>conftest.$ac_ext <<_ACEOF
 #if HAVE_NETDB_H
 #include <netdb.h>
 #endif
-#if HAVE_RLIM_T
+#if HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
 #endif
 #if HAVE_STDINT_H
@@ -7732,7 +7732,7 @@ cat >>conftest.$ac_ext <<_ACEOF
 #if HAVE_NETDB_H
 #include <netdb.h>
 #endif
-#if HAVE_RLIM_T
+#if HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
 #endif
 #if HAVE_STDINT_H
@@ -7778,7 +7778,7 @@ cat >>conftest.$ac_ext <<_ACEOF
 #if HAVE_NETDB_H
 #include <netdb.h>
 #endif
-#if HAVE_RLIM_T
+#if HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
 #endif
 #if HAVE_STDINT_H
@@ -7824,7 +7824,7 @@ cat >>conftest.$ac_ext <<_ACEOF
 #if HAVE_NETDB_H
 #include <netdb.h>
 #endif
-#if HAVE_RLIM_T
+#if HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
 #endif
 #if HAVE_STDINT_H
@@ -7870,7 +7870,7 @@ cat >>conftest.$ac_ext <<_ACEOF
 #if HAVE_NETDB_H
 #include <netdb.h>
 #endif
-#if HAVE_RLIM_T
+#if HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
 #endif
 #if HAVE_STDINT_H
@@ -7916,7 +7916,7 @@ cat >>conftest.$ac_ext <<_ACEOF
 #if HAVE_NETDB_H
 #include <netdb.h>
 #endif
-#if HAVE_RLIM_T
+#if HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
 #endif
 #if HAVE_STDINT_H

--- a/xinetd/confparse.c
+++ b/xinetd/confparse.c
@@ -40,6 +40,7 @@
 #include "inet.h"
 #include "main.h"
 
+extern int inetd_ipv6;
 extern int inetd_compat;
 
 /*

--- a/xinetd/inet.c
+++ b/xinetd/inet.c
@@ -23,6 +23,8 @@
 #include "parsesup.h"
 #include "nvlists.h"
 
+extern int inetd_ipv6;
+
 static int get_next_inet_entry( int fd, pset_h sconfs, 
                           struct service_config *defaults);
 
@@ -355,6 +357,21 @@ static int get_next_inet_entry( int fd, pset_h sconfs,
          }
          SC_SERVER_ARGV(scp)[u] = p;
       }
+
+      /* Set the IPv6 flag if we were passed the -inetd_ipv6 option */
+      if ( inetd_ipv6 )
+      {
+         nvp = nv_find_value( service_flags, "IPv6" );
+         if ( nvp == NULL )
+         {
+            parsemsg( LOG_WARNING, func, "inetd.conf - Bad foo %s", name ) ;
+            pset_destroy(args);
+            sc_free(scp);
+            return -1;
+         }
+         M_SET(SC_XFLAGS(scp), nvp->value);
+      }
+
       /* Set the reuse flag, as this is the default for inetd */
       nvp = nv_find_value( service_flags, "REUSE" );
       if ( nvp == NULL )

--- a/xinetd/options.c
+++ b/xinetd/options.c
@@ -30,6 +30,7 @@ int logprocs_option ;
 unsigned logprocs_option_arg ;
 int stayalive_option=0;
 char *program_name ;
+int inetd_ipv6 = 0 ;
 int inetd_compat = 0 ;
 int dont_fork = 0;
 
@@ -128,6 +129,8 @@ int opt_recognize( int argc, char *argv[] )
             fprintf(stderr, "\n");
             exit(0);
          }
+         else if ( strcmp ( &argv[ arg ][ 1 ], "inetd_ipv6" ) == 0 )
+            inetd_ipv6 = 1;
          else if ( strcmp ( &argv[ arg ][ 1 ], "inetd_compat" ) == 0 )
             inetd_compat = 1;
       }

--- a/xinetd/xinetd.man
+++ b/xinetd/xinetd.man
@@ -106,6 +106,12 @@ This option causes xinetd to read /etc/inetd.conf in addition to the
 standard xinetd config files.  /etc/inetd.conf is read after the
 standard xinetd config files.
 .TP
+.BI \-inetd_ipv6
+This option causes xinetd to bind to IPv6 (AF_INET6) addresses for
+inetd compatibility lines (see previous option).  This only affects
+how /etc/inetd.conf is interpreted and thus only has any effect if
+the \-inetd_compat option is also used.
+.TP
 .BI \-cc " interval"
 This option instructs
 .B xinetd


### PR DESCRIPTION
HAVE_RLIM_T check will not let sys/resource.h to be checked and
rlim_t is defined in sys/resource.h so the check would fail.

Signed-off-by: Khem Raj raj.khem@gmail.com
Signed-off-by: Maxin B. John maxin.john@intel.com
