### PR TITLE
Fix the handling of file descriptors when new connections fd are in the 0~MAX_PASS_FD range

### DIFF
--- a/xinetd/child.c
+++ b/xinetd/child.c
@@ -321,11 +321,6 @@ void child_process( struct server *serp )
    signals_pending[0] = -1;
    signals_pending[1] = -1;
 
-   Sclose(0);
-   Sclose(1);
-   Sclose(2);
-
-
 #ifdef DEBUG_SERVER
    if ( debug.on )
    {

--- a/xinetd/child.c
+++ b/xinetd/child.c
@@ -168,7 +168,8 @@ void exec_server( const struct server *serp )
    }
 #endif
 
-   (void) Sclose( descriptor ) ;
+   if ( descriptor > MAX_PASS_FD )
+      (void) Sclose( descriptor ) ;
 
 #ifndef solaris
 #if !defined(HAVE_SETSID)


### PR DESCRIPTION
See:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=211038
https://redmine.pfsense.org/issues/6315

This happens because the UDP service was using the 0 (zero) file descriptor for the (new) received connection (which was later closed before it could be used by the child).

This is easily reproducible by setting a single UDP service in xinted.
