### PR TITLE
Add REMOTE_PORT from connection to environment

### DIFF
--- a/xinetd/child.c
+++ b/xinetd/child.c
@@ -383,6 +383,12 @@ void child_process( struct server *serp )
             msg( LOG_ERR, func, "Error adding REMOTE_HOST variable for %s: %m", SC_NAME(scp) );
             _exit( 1 ) ;
          }
+
+         strx_sprint(buff, sizeof(buff)-1, "REMOTE_PORT=%d", ntohs(cp->co_remote_address.sa_in.sin_port));
+         if( env_addstr(SC_ENV(scp)->env_handle, buff) != ENV_OK ) {
+            msg( LOG_ERR, func, "Error adding REMOTE_PORT variable for %s: %m", SC_NAME(scp) );
+            _exit( 1 ) ;
+         }
 #endif
          exec_server( serp ) ;
       }


### PR DESCRIPTION
I've added REMOTE_PORT into export of variable to the environment.
It is very useful if you transparent redirect connection from multiple
destinations to one service. (for example every outgoing SMTP connect
should go to 10.0.0.1)

If you want to process the connection from a script behind xinetd and
want to know the original destination you have to parse the output of
'/proc/net/nf_conntrack' which is hard if you want to assign at least
two connection from the same host to the same service. If you want to
make something while the connection is open you need to know REMOTE_HOST
and REMOTE_PORT.