### PR TITLE
Fix a file descriptor leak.

### DIFF
--- a/xinetd/xgetloadavg.c
+++ b/xinetd/xgetloadavg.c
@@ -34,7 +34,7 @@ double xgetloadavg(void)
 
    if( fscanf(fd, "%lf", &ret) != 1 ) {
       perror("fscanf");
-      return -1;
+      ret = -1;
    }
 
    fclose(fd);


### PR DESCRIPTION
Early return on error in xloadavg leaves fd open (patch taken from Debian, see https://anonscm.debian.org/cgit/collab-maint/xinetd.git/tree/debian/patches).